### PR TITLE
Improved Collision Detection to avoid overlapping axes

### DIFF
--- a/demo/scripts/date-axes.js
+++ b/demo/scripts/date-axes.js
@@ -52,6 +52,11 @@ var axesDefinitions = [
         title: 'Years Overlapping',
         dateStart: new Date(1999, 8, 31),
         dateEnd: new Date(2013, 1, 4)
+    },
+    {
+        title: 'Months Overlapping',
+        dateStart: new Date(1995, 5, 15),
+        dateEnd: new Date(2005, 10, 14)
     }];
 
 function createAxesDefArrayOfWidth(axisWidth) {
@@ -100,7 +105,9 @@ function renderAxesArrayIntoDiv(div, axesDefinitionArray) {
                 .append('g')
                 .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
                 .call(axis);
+
         });
+
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,30 +1,31 @@
 {
-    "version": "0.2.3",
-    "name": "o-charts",
-    "description": "FT style charts, axes, scales etc",
-    "private": true,
-    "main": "src/scripts/o-charts.js",
-    "scripts": {
-        "build": "component build",
-        "bump": "component bump",
-        "release": "npm test && component release",
-        "report": "component serve test/coverage/phantomjs/",
-        "start": "component build && component serve",
-        "tdd": "component test tdd",
-        "test": "jshint src && component build && component test"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/ft-interactive/o-charts.git"
-    },
-    "author": "tom pearson",
-    "license": "ISC",
-    "devDependencies": {
-        "browserify-istanbul": "^0.2.1",
-        "component-helper": "1.3.1-rc.1",
-        "jshint": "^2.6.3"
-    },
-    "browser": {
-        "d3": "./bower_components/d3/d3.js"
-    }
+  "version": "0.2.3",
+  "name": "o-charts",
+  "description": "FT style charts, axes, scales etc",
+  "private": true,
+  "main": "src/scripts/o-charts.js",
+  "scripts": {
+    "build": "component build",
+    "bump": "component bump",
+    "release": "npm test && component release",
+    "report": "component serve test/coverage/phantomjs/",
+    "start": "component build && component serve",
+    "tdd": "component test tdd",
+    "test": "jshint src && component build && component test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ft-interactive/o-charts.git"
+  },
+  "author": "tom pearson",
+  "license": "ISC",
+  "devDependencies": {
+    "browserify-istanbul": "^0.2.1",
+    "component-helper": "1.3.1-rc.1",
+    "jshint": "^2.6.3"
+  },
+  "browser": {
+    "d3": "./bower_components/d3/d3.js"
+  },
+  "dependencies": {}
 }

--- a/src/scripts/axis/date.js
+++ b/src/scripts/axis/date.js
@@ -2,7 +2,6 @@ var d3 = require('d3');
 var labels = require('../util/labels.js');
 var dates = require('../util/dates.js');
 var dateScale = require('./date.scale.js');
-var styler = require('../util/chart-attribute-styles');
 var timeDiff = dates.timeDiff;
 
 function dateAxis() {
@@ -28,15 +27,7 @@ function dateAxis() {
         g = g.append('g').attr('transform', 'translate(' + config.xOffset + ',' + config.yOffset + ')');
 
         g.append('g').attr('class', 'x axis').each(function () {
-            var g = d3.select(this);
-            labels.add(g, config);
-            //remove text-anchor attribute from year positions
-            g.selectAll('.primary text').attr({
-                x: null,
-                y: null,
-                dy: 15 + config.tickSize
-            });
-            styler(g);
+            labels.add(d3.select(this), config);
         });
 
         if (!config.showDomain) {

--- a/src/scripts/util/labels.js
+++ b/src/scripts/util/labels.js
@@ -1,5 +1,6 @@
 var d3 = require('d3');
 var dates = require('../util/dates');
+var styler = require('./chart-attribute-styles');
 var dateFormatter = dates.formatter;
 
 module.exports = {
@@ -24,10 +25,20 @@ module.exports = {
     add: function(g, config){
         var self = this;
         var options = { row: 0 };
+
         config.axes.forEach(function (axis, i) {
             self.addRow(g, axis, options, config);
             options.row ++;
         });
+
+        //remove text-anchor attribute from year positions
+        g.selectAll('.primary text').attr({
+            x: null,
+            y: null,
+            dy: 15 + config.tickSize
+        });
+
+
     },
     addRow: function(g, axis, options, config){
         var rowClass = (options.row) ? 'secondary': 'primary';
@@ -35,6 +46,9 @@ module.exports = {
             .attr('class', rowClass)
             .attr('transform', 'translate(0,' + (options.row * config.lineHeight) + ')')
             .call(axis);
+        // style the row before we do any removing, to ensure that
+        // collision detection is done correctly
+        styler(g);
 
         this.removeDuplicates(g, '.' + rowClass + ' text');
         if (options.extendTicks) {
@@ -50,6 +64,7 @@ module.exports = {
             this.removeMonths(g, axis, options, config);
         }
         this.removeOverlapping(g, '.' + rowClass + ' text');
+
     },
 
     intersection: function (a, b) {

--- a/test/functional/date-axes.spec.js
+++ b/test/functional/date-axes.spec.js
@@ -1,22 +1,31 @@
-/* Add HTML + CSS to setup page for functional testing */
-require('../helper').loadAssets('date-axes');
-
-require('../../demo/scripts/date-axes').init();
-
 /* Start Test */
 describe('When the date axis is', function () {
 
+    beforeEach(function() {
+        require('../helper').loadAssets('date-axes');
+        require('../../demo/scripts/date-axes').init();
+    });
+
     describe('a day or less,', function () {
-        var dayOrLess = document.querySelector('#views .axis-test:nth-child(1) svg');
-        var x = dayOrLess.querySelector('.x.axis');
-        var ticks = x.querySelectorAll('.primary .tick');
-        var labels = x.querySelectorAll('.primary .tick text');
-        var firstTick = ticks[0];
-        var finalTick = ticks[ticks.length-1];
-        var firstTickLine = firstTick.querySelectorAll('line');
-        var firstTickLabel = firstTick.querySelectorAll('text');
-        var finalTickLine = finalTick.querySelectorAll('line');
-        var finalTickLabel = finalTick.querySelectorAll('text');
+        var dayOrLess, x, ticks, labels, firstTick, finalTick, firstTickLine,
+            firstTickLabel, finalTickLine, finalTickLabel;
+
+        beforeEach(function() {
+            dayOrLess = document.querySelector('#views .axis-test:nth-child(1) svg');
+            x = dayOrLess.querySelector('.x.axis');
+            ticks = x.querySelectorAll('.primary .tick');
+            labels = x.querySelectorAll('.primary .tick text');
+            firstTick = ticks[0];
+            finalTick = ticks[ticks.length-1];
+            firstTickLine = firstTick.querySelectorAll('line');
+            firstTickLabel = firstTick.querySelectorAll('text');
+            finalTickLine = finalTick.querySelectorAll('line');
+            finalTickLabel = finalTick.querySelectorAll('text');
+        });
+
+        afterEach(function() {
+            document.body.innerHTML = '';
+        });
 
         it('one tick for each hour is shown', function () {
             expect(ticks.length).toBe(12);
@@ -43,12 +52,22 @@ describe('When the date axis is', function () {
     });
 
     describe('a day or less (small),', function () {
-        var dayOrLessSmall = document.querySelector('#viewsSmall .axis-test:nth-child(1) svg');
-        var x = dayOrLessSmall.querySelector('.x.axis');
-        var ticks = x.querySelectorAll('.primary .tick');
-        var labels = x.querySelectorAll('.primary .tick text');
-        var firstTick = ticks[0];
-        var firstTickLine = firstTick.querySelectorAll('line');
+        var dayOrLessSmall, x, ticks, labels, firstTick, firstTickLine;
+
+        beforeEach(function() {
+
+            dayOrLessSmall = document.querySelector('#viewsSmall .axis-test:nth-child(1) svg');
+            x = dayOrLessSmall.querySelector('.x.axis');
+            ticks = x.querySelectorAll('.primary .tick');
+            labels = x.querySelectorAll('.primary .tick text');
+            firstTick = ticks[0];
+            firstTickLine = firstTick.querySelectorAll('line');
+
+        });
+
+        afterEach(function() {
+            document.body.innerHTML = '';
+        });
 
         it('one tick for each hour is shown', function () {
             expect(ticks.length).toBe(12);
@@ -67,12 +86,20 @@ describe('When the date axis is', function () {
     });
 
     describe('a few weeks,', function () {
-        var aFewWeeks = document.querySelector('#views .axis-test:nth-child(2) svg');
-        var x = aFewWeeks.querySelector('.x.axis');
-        var ticks = x.querySelectorAll('.primary .tick');
-        var labels = x.querySelectorAll('.primary .tick text');
-        var firstTick = ticks[0];
-        var firstTickLine = firstTick.querySelectorAll('line');
+        var aFewWeeks, x, ticks, labels, firstTick, firstTickLine;
+
+        beforeEach(function() {
+            aFewWeeks = document.querySelector('#views .axis-test:nth-child(2) svg');
+            x = aFewWeeks.querySelector('.x.axis');
+            ticks = x.querySelectorAll('.primary .tick');
+            labels = x.querySelectorAll('.primary .tick text');
+            firstTick = ticks[0];
+            firstTickLine = firstTick.querySelectorAll('line');
+        });
+
+        afterEach(function() {
+            document.body.innerHTML = '';
+        });
 
         it('one tick for each day is shown', function () {
             expect(ticks.length).toBe(26);
@@ -89,12 +116,20 @@ describe('When the date axis is', function () {
     });
 
     describe('between 3 - 15 years,', function () {
-        var threeToFifteenYears = document.querySelector('#views .axis-test:nth-child(5) svg');
-        var x = threeToFifteenYears.querySelector('.x.axis');
-        var ticks = x.querySelectorAll('.primary .tick');
-        var labels = x.querySelectorAll('.primary .tick text');
-        var firstTick = ticks[0];
-        var firstTickLine = firstTick.querySelectorAll('line');
+        var threeToFifteenYears, x, ticks, labels, firstTick, firstTickLine;
+
+        beforeEach(function() {
+            threeToFifteenYears = document.querySelector('#views .axis-test:nth-child(5) svg');
+            x = threeToFifteenYears.querySelector('.x.axis');
+            ticks = x.querySelectorAll('.primary .tick');
+            labels = x.querySelectorAll('.primary .tick text');
+            firstTick = ticks[0];
+            firstTickLine = firstTick.querySelectorAll('line');
+        });
+
+        afterEach(function() {
+            document.body.innerHTML = '';
+        });
 
         it('shows one tick for each year', function () {
             expect(ticks.length).toBe(10);
@@ -126,10 +161,18 @@ describe('When the date axis is', function () {
     });
 
     describe('has 2 ticks very close to each other, ', function () {
-        var overlapping = document.querySelector('#viewsSmall .axis-test:nth-child(9) svg');
-        var overlappingX = overlapping.querySelector('.x.axis');
-        var ticks = overlappingX.querySelectorAll('.primary .tick');
-        var overlappingLabels = overlappingX.querySelectorAll('.primary .tick text');
+        var overlapping, overlappingX, ticks, overlappingLabels;
+
+        beforeEach(function() {
+            overlapping = document.querySelector('#viewsSmall .axis-test:nth-child(9) svg');
+            overlappingX = overlapping.querySelector('.x.axis');
+            ticks = overlappingX.querySelectorAll('.primary .tick');
+            overlappingLabels = overlappingX.querySelectorAll('.primary .tick text');
+        });
+
+        afterEach(function() {
+            document.body.innerHTML = '';
+        });
 
         it('they should not overlap (ng-65)', function () {
             expect(ticks.length).toBe(15);
@@ -150,4 +193,32 @@ describe('When the date axis is', function () {
             expect(overlappingLabels[4].textContent).toBe('13');
         });
     });
+
+    describe('X axis labels', function() {
+        var intersection = require('../../src/scripts/util/labels').intersection;
+        var axes;
+
+        beforeEach(function() {
+            axes = document.querySelectorAll('g.x.axis g.primary,g.secondary');
+        });
+
+        afterEach(function() {
+            document.body.innerHTML = '';
+        });
+
+        it('should never overlap', function() {
+            var ax, i, j, textLabels, parent;
+            for (i = 0; i < axes.length; i ++) {
+                ax = axes[i];
+                textLabels = ax.querySelectorAll('text');
+                for (j = 1; j < textLabels.length; j++) {
+                    var previous = textLabels[j-1].getBoundingClientRect();
+                    var current = textLabels[j].getBoundingClientRect();
+                    expect(intersection(previous, current)).toBe(false);
+                }
+            }
+        });
+
+    });
+
 });


### PR DESCRIPTION
The `removeOverlapping` method was being called *before* the axes had their final styling, which meant the computations were not correct, and some collisions would be accepted.

I've refactored the label generation so that styling happens now inside the label addRow method, which ensures the labels are in the correct place before the collision detection prune is executed.

I've also added a test that ensures none of the labels overlap *ever* 💯

This should fix #41 