### PR TITLE
Fix for non-centered category axis labels.

### DIFF
--- a/src/scripts/axis/category.js
+++ b/src/scripts/axis/category.js
@@ -21,7 +21,8 @@ function categoryAxis() {
         xOffset: 0,
         labelWidth: 0,
         showDomain: false,
-        categorical: false
+        categorical: false,
+        keepD3Style: true
     };
 
     function render(g) {
@@ -31,13 +32,6 @@ function categoryAxis() {
         g.append('g').attr('class', 'x axis').each(function () {
             var g = d3.select(this);
             labels.add(g, config);
-            //remove text-anchor attribute from year positions
-            g.selectAll('.primary text').attr({
-                x: null,
-                y: null,
-                dy: 15 + config.tickSize
-            });
-            styler(g, true);
         });
 
         if (!config.showDomain) {

--- a/src/scripts/axis/date.js
+++ b/src/scripts/axis/date.js
@@ -19,7 +19,8 @@ function dateAxis() {
         yOffset: 0,
         xOffset: 0,
         labelWidth: 0,
-        showDomain: false
+        showDomain: false,
+        keepD3Style: false
     };
 
     function render(g) {

--- a/src/scripts/util/labels.js
+++ b/src/scripts/util/labels.js
@@ -38,19 +38,22 @@ module.exports = {
             dy: 15 + config.tickSize
         });
 
-
     },
+
     addRow: function(g, axis, options, config){
         var rowClass = (options.row) ? 'secondary': 'primary';
         g.append('g')
             .attr('class', rowClass)
             .attr('transform', 'translate(0,' + (options.row * config.lineHeight) + ')')
             .call(axis);
+
         // style the row before we do any removing, to ensure that
         // collision detection is done correctly
-        styler(g);
+        styler(g, config.keepD3Style);
 
-        if (config.categorical) return;
+        if (config.categorical) {
+            return;
+        }
 
         this.removeDuplicates(g, '.' + rowClass + ' text');
         if (options.extendTicks) {

--- a/test/functional/category-axes.spec.js
+++ b/test/functional/category-axes.spec.js
@@ -114,4 +114,22 @@ describe('category axis', function () {
 
     });
 
+    describe('label positions', function () {
+        it('Text labels should have textAnchor: center', function() {
+            var primaryTicks = document.querySelectorAll('.x.axis .primary .tick text');
+            var secondaryTicks = document.querySelectorAll('.x.axis .secondary .tick text');
+
+            // turn NodeList into Arrays;
+            primaryTicks = Array.prototype.slice.call(primaryTicks);
+            secondaryTicks = Array.prototype.slice.call(secondaryTicks);
+
+            var ticks = primaryTicks.concat(secondaryTicks);
+
+            for (var i = 0; i < ticks.length; i++) {
+                expect(ticks[i].style.textAnchor).toEqual('middle');
+            }
+
+        });
+    });
+
 });

--- a/test/functional/date-axes.spec.js
+++ b/test/functional/date-axes.spec.js
@@ -219,6 +219,22 @@ describe('When the date axis is', function () {
             }
         });
 
+        it('should have no textAnchor', function() {
+            var primaryTicks = document.querySelectorAll('.x.axis .primary .tick text');
+            var secondaryTicks = document.querySelectorAll('.x.axis .secondary .tick text');
+
+            // turn NodeList into Arrays;
+            primaryTicks = Array.prototype.slice.call(primaryTicks);
+            secondaryTicks = Array.prototype.slice.call(secondaryTicks);
+
+            var ticks = primaryTicks.concat(secondaryTicks);
+
+            for (var i = 0; i < ticks.length; i++) {
+                expect(ticks[i].style.textAnchor).toEqual("");
+            }
+        });
+
     });
+
 
 });

--- a/test/karma.functional.js
+++ b/test/karma.functional.js
@@ -23,7 +23,8 @@ module.exports = function(config) {
             'src/**/*.txt',
             'src/**/*.csv',
             'src/**/*.hbs'
-        ]
+        ],
+        browserNoActivityTimeout: 20000
     };
     var pkg = require('../package.json');
     karmaConfig.browser = pkg.browser || {};


### PR DESCRIPTION
With #50, i introduced a bug where line chart date axis styles were being applied also to category axes, which made the labels on the axes be right-aligned:
![screen shot 2015-06-01 at 14 44 56](https://cloud.githubusercontent.com/assets/780409/7914997/8a42df92-0872-11e5-93fe-d07231aefc6d.png)

I've fixed the issue and added a test so that this doesn't happen again.