### PR TITLE
Order grouped data properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "devDependencies": {
     "browserify-istanbul": "^0.2.1",
     "component-helper": "1.3.1-rc.1",
-    "jshint": "^2.6.3"
+    "jshint": "^2.6.3",
+    "karma-mocha-reporter": "^1.0.2"
   },
   "browser": {
     "d3": "./bower_components/d3/d3.js"

--- a/src/scripts/chart/column.js
+++ b/src/scripts/chart/column.js
@@ -29,7 +29,7 @@ function formatData(model, series) {
             value: (Array.isArray(d.values)) ? d.values[0][series.key] : d[series.key]
         };
     }).filter(function (d) {
-        return (d.value !== null);
+        return (d.value !== null && !isNaN(d.value));
     });
     return data;
 }

--- a/src/scripts/util/data.model.js
+++ b/src/scripts/util/data.model.js
@@ -144,16 +144,14 @@ function setKey(model) {
 }
 
 function groupDates(m, units){
-	var i=0;
-	var firstDate;
-	m.data = d3.nest()
-		.key(function(d)  {
-            firstDate = firstDate || d[m.x.series.key];
-            var dateStr = [dateUtil.formatter[units[0]](d[m.x.series.key], i++, firstDate)];
-            units[1] && dateStr.push(dateUtil.formatter[units[1]](d[m.x.series.key], i++, firstDate));
-            return  dateStr.join(' ');
-		})
-		.entries(m.data);
+    var firstDate = m.data[0][m.x.series.key];
+    var data = [];
+    m.data.forEach(function(d,i){
+        var dateStr = [dateUtil.formatter[units[0]](d[m.x.series.key], i, firstDate)];
+        units[1] && dateStr.push(dateUtil.formatter[units[1]](d[m.x.series.key], i, firstDate));
+        data.push({key:dateStr.join(' '),values:[d]});
+    });
+    m.data = data;
 	m.x.series.key = 'key';
 	return m.data;
 }

--- a/test/karma.functional.js
+++ b/test/karma.functional.js
@@ -1,15 +1,15 @@
 module.exports = function(config) {
     var karmaConfig = {
         basePath: '..',
-        browsers: ['PhantomJS'],
+        browsers: ['Chrome'],
         frameworks: ['jasmine', 'browserify'],
-        reporters: ['progress'],
+        reporters: ['mocha'],
         preprocessors: {
             'test/functional/**/*.js': ['browserify'],
             '_site/*.html': ['html2js']
         },
         plugins: [
-            'karma-browserify', 'karma-jasmine', 'karma-coverage', 'karma-phantomjs-launcher', 'karma-chrome-launcher', 'karma-html2js-preprocessor'
+            'karma-browserify',  'karma-mocha-reporter', 'karma-jasmine', 'karma-coverage', 'karma-phantomjs-launcher', 'karma-chrome-launcher', 'karma-html2js-preprocessor'
         ],
         files: [
             {pattern: '_site/**/vendor.*', included: true, served: true, watched: true},

--- a/test/karma.unit.js
+++ b/test/karma.unit.js
@@ -1,7 +1,7 @@
 module.exports = function(config) {
     var karmaConfig = {
         basePath: '..',
-        browsers: ['PhantomJS'],
+        browsers: ['Chrome'],
         frameworks: ['jasmine', 'browserify'],
         reporters: ['progress', 'coverage'],
         preprocessors: {

--- a/test/unit/util/data.model.spec.js
+++ b/test/unit/util/data.model.spec.js
@@ -21,6 +21,25 @@ describe('data model', function () {
 
     });
 
+    it('doesnt reorder grouped dates (chrome test)', function(){
+        var model = new DataModel('column', {
+            units: ['yearly'],
+            data: [
+                {date: new Date('2008'), value: 10, value2: 1},
+                {date: new Date('2009'), value: 11, value2: 1},
+                {date: new Date('2010'), value: 12, value2: 1},
+                {date: new Date('2011'), value: 13, value2: 1}
+            ],
+            x: { series: ['date']},
+            y: { series: ['value', 'value2']}
+        });
+        expect(model.groupData).toBe(true);
+        expect(model.data[0].key).toBe('2008');
+        expect(model.data[1].key).toBe('09');
+        expect(model.data[2].key).toBe('10');
+        expect(model.data[3].key).toBe('11');
+    });
+
     it('returns values as set in options', function(){
         var model = new DataModel('line', {
             height: 100,


### PR DESCRIPTION
prevent NaN error when ':' or  '-' is parsed to plotter
prevent d3 from ordering by key on grouped dates
add Chrome to default testing browsers