### PR TITLE
N/A labels to signal null data on column charts

### DIFF
--- a/demo/scripts/column-chart.js
+++ b/demo/scripts/column-chart.js
@@ -188,7 +188,34 @@ var fixtures = {
         { key: '2005 Q3', value: 1.03, value2:  1.4},
         { key: '2005 Q4', value:     1.348, value2:  1.9},
         { key: '2006 Q1', value:     -1.048, value2:  -2}
-    ]
+    ],
+    nullValues : [
+        { date: new Date('6/30/05'), value: 1.027},
+        { date: new Date('9/30/05'), value: 1.03},
+        { date: new Date('12/30/05'), value:     1.348},
+        { date: new Date('3/31/06'), value:      0.583},
+        { date: new Date('6/30/06'), value:      0.501},
+        { date: new Date('9/29/06'), value:      null},
+        { date: new Date('12/29/06'), value:     0.753},
+        { date: new Date('3/30/07'), value:      0.763},
+        { date: new Date('6/29/07'), value:      0.601},
+        { date: new Date('9/28/07'), value:      null},
+        { date: new Date('12/31/07'), value:     0.468},
+        { date: new Date('3/31/08'), value:      0.313}
+    ],
+    nullMultiple:[
+        {date: new Date('3/31/05'), value: Math.floor(Math.random() * 40) + 10, value2: 99, value3: 26},
+        {date: new Date('6/30/05'), value: Math.floor(Math.random() * 40) + 10, value2: null, value3: 21},
+        {date: new Date('9/30/05'), value: Math.floor(Math.random() * 40) + 10, value2: 70, value3: 13},
+        {date: new Date('12/30/05'), value: Math.floor(Math.random() * 40) + 10, value2: 10, value3: null}
+    ],
+    nullStack:[
+        {myDateColumn: new Date('3/31/05'), value: 50, value2: 99, value3: 26, value4: 40, value5: 15},
+        {myDateColumn: new Date('6/30/05'), value: 25, value2: 10, value3: 21, value4: 36, value5: null},
+        {myDateColumn: new Date('9/30/05'), value: 75, value2: 70, value3: null, value4: 12, value5: 110},
+        {myDateColumn: new Date('12/30/05'), value: null, value2: 10, value3: 29, value4: 31, value5: 40},
+        {myDateColumn: new Date('5/30/06'), value: 133, value2: 25, value3: 72, value4: 105, value5: 200}
+    ],
 };
 
 var units = {
@@ -203,7 +230,10 @@ var units = {
     stack: ['quarterly', 'yearly'],
     stackMonthly: ['monthly', 'yearly'],
     multipleWithNegatives: ['quarterly', 'yearly'],
-    stackWithAllNegatives: ['quarterly', 'yearly']
+    stackWithAllNegatives: ['quarterly', 'yearly'],
+    nullValues: ['quarterly', 'yearly'],
+    nullMultiple: ['quarterly', 'yearly'],
+    nullStack: ['quarterly', 'yearly']
 };
 var ySeriesData = {
     categories: ['value', 'value2'],
@@ -211,8 +241,10 @@ var ySeriesData = {
     dateCategories: ['value', 'value2'],
     quarterCategories: ['value', 'value2'],
     multiple: ['value', 'value2', 'value3'],
+    nullMultiple: ['value', 'value2', 'value3'],
     multipleWithNegatives: ['value', 'value2', 'value3'],
     stack: ['value', 'value2', 'value3', 'value4', 'value5'],
+    nullStack: ['value', 'value2', 'value3', 'value4', 'value5'],
     stackWithNegatives: ['value', 'value2', 'value3', 'value4', 'value5'],
     stackWithAllNegatives: ['value', 'value2', 'value3', 'value4', 'value5'],
     stackMonthly: ['value', 'value2', 'value3', 'value4', 'value5']
@@ -223,6 +255,7 @@ var xSeriesData = {
     dateCategories: {key:'key', label:'Colours'},
     quarterCategories: {key:'key', label:'Colours'},
     stack: {key:'myDateColumn', label:'yearly'},
+    nullStack: {key:'myDateColumn', label:'yearly'},
     stackMonthly: {key:'myDateColumn', label:'yearly'},
     stackWithAllNegatives: {key:'myDateColumn', label:'yearly'}
 };
@@ -241,7 +274,7 @@ function getChartData(timeFrame){
         y: { series: ySeries },
         units: units[timeFrame],
         data: fixtures[timeFrame],
-        stack: ['stack','stackMonthly', 'stackWithAllNegatives', 'categoriesStack'].indexOf(timeFrame)>-1,
+        stack: ['stack', 'nullStack','stackMonthly', 'stackWithAllNegatives', 'categoriesStack'].indexOf(timeFrame)>-1,
         dataType: ['categories','categoriesStack','dateCategories', 'quarterCategories'].indexOf(timeFrame)>-1 ? 'categorical' : 'time'
     };
 }
@@ -253,7 +286,8 @@ module.exports = {
         var demos = [
             'quarters','quartersWithNegative','years','yearsWithNegative','decade', 'month',
             'multiple', 'time', 'stack', 'stackMonthly', 'multipleWithNegatives', 'stackWithAllNegatives',
-            'categories', 'categoriesStack', 'dateCategories', 'quarterCategories'];
+            'categories', 'categoriesStack', 'dateCategories', 'quarterCategories',
+            'nullMultiple', 'nullValues', 'nullStack'];
         demos.forEach(function(timeFrame, i){
             var textContent = '';
             if (i===7){

--- a/src/scripts/chart/column.js
+++ b/src/scripts/chart/column.js
@@ -19,18 +19,58 @@ function plotSeries(plotSVG, model, createdAxes, series, seriesNumber){
         .attr('height', function (d, i){ return plot.columnHeight(d.value); })
         .attr('width',  function (d, i){ return plot.columnWidth(d, i); });
 
+
+    if (!model.stack) {
+        // add N/As for null values
+        s.selectAll('text.null-label')
+            .data(data._nulls)
+            .enter()
+            .append('text')
+            .attr('class', 'null-label')
+            .attr('x',  function (d, i) { return plot.x(d.key, seriesNumber); })
+            .attr('y',  function (d, i) { return plot.y(d.value, i); })
+            .attr('dy', '-0.5em')
+            .attr('dx', function (d, i) { return plot.columnWidth(d, i) / 2;})
+            .text('n/a');
+    }
+
     styler(plotSVG);
+
+    if (!model.stack) {
+        // make those labels who don't fit smaller
+        s.selectAll('text.null-label')
+            .each(function(d, i) {
+                var w = this.getBoundingClientRect();
+                if ((w.width + 2) >= plot.columnWidth(d, i)) {
+                    this.innerHTML = '–';
+                }
+            });
+    }
 }
 
 function formatData(model, series) {
+
+    var nulls = [];
+
     var data = model.data.map(function (d){
         return{
             key:d[model.x.series.key],
             value: (Array.isArray(d.values)) ? d.values[0][series.key] : d[series.key]
         };
     }).filter(function (d) {
-        return (d.value !== null && !isNaN(d.value));
+        var isNull = !(d.value !== null && !isNaN(d.value));
+        if (isNull) nulls.push(d);
+        // if we're stacking - we transform nulls
+        // into zeros to avoid problems
+        if (model.stack && isNull) {
+            d.value = 0;
+            return true;
+        }
+        return !isNull;
     });
+
+    data._nulls = nulls;
+
     return data;
 }
 

--- a/src/scripts/util/chart-attribute-styles.js
+++ b/src/scripts/util/chart-attribute-styles.js
@@ -175,7 +175,15 @@ function applyAttributes(g, keepD3Styles) {
             'attributes': {
                 'stroke': 'rgb(184,177,169)'
             }
+        }, {
+            'selector': '.series text.null-label',
+            'attributes': {
+                'text-anchor': 'middle',
+                'font-size': 10,
+                'fill': 'rgba(0, 0, 0, 0.4)'
+            }
         },
+
         //text
         {
             'selector': '.chart-title text, .chart-title tspan',

--- a/test/functional/column-chart.spec.js
+++ b/test/functional/column-chart.spec.js
@@ -81,6 +81,27 @@ describe('column-chart.js', function(){
 
     });
 
+    describe('null values', function() {
+        it('has N/A labels when null values are present', function() {
+            var nullValsGraph = document.querySelector('#column-chart__nullValues .width600 svg');
+            var nullLabels = nullValsGraph.querySelectorAll('text.null-label');
+            expect(nullLabels.length).toBe(2);
+            for (var i = 0; i < nullLabels.length; i++) {
+                expect(nullLabels[i].innerHTML).toBe('n/a');
+            }
+        });
+
+        it('has ≁ labels when null values are present on small charts', function() {
+            var nullValsGraph = document.querySelector('#column-chart__nullMultiple .width300 svg');
+            var nullLabels = nullValsGraph.querySelectorAll('text.null-label');
+            expect(nullLabels.length).toBe(2);
+            for (var i = 0; i < nullLabels.length; i++) {
+                expect(nullLabels[i].innerHTML).toBe('–');
+            }
+        });
+
+    });
+
     describe('y-axis values', function(){
 
         it('can positive only numbers', function(){


### PR DESCRIPTION
adds N/A labels on column charts where null values are encountered, provided they don't take too much space. If they do take a lot of space, we use the unicode character "≁" to still provide a visually equivalent result:

![screen shot 2015-06-03 at 11 45 54](https://cloud.githubusercontent.com/assets/780409/7958338/44970a5c-09e6-11e5-82fb-a98ee424bb26.png)