### PR TITLE
Ensure all-negative valued domains start from zero on column and bar charts

### DIFF
--- a/demo/scripts/column-chart.js
+++ b/demo/scripts/column-chart.js
@@ -237,6 +237,39 @@ var fixtures = {
         { date: new Date('5/13/2014'), value:     -0.239283},
         { date: new Date('5/14/2014'), value:     0.619157},
         { date: new Date('5/15/2014'), value:     0.090189}
+    ],
+    allNegative : [
+        { date: new Date('01/01/2012'), value:  -74.891},
+        { date: new Date('02/01/2012'), value:  -73.203},
+        { date: new Date('03/01/2012'), value:  -70.019},
+        { date: new Date('04/01/2012'), value:  -67.087},
+        { date: new Date('05/01/2012'), value:  -64.752},
+        { date: new Date('06/01/2012'), value:  -61.148},
+        { date: new Date('07/01/2012'), value:  -60.145},
+        { date: new Date('08/01/2012'), value:  -57.734},
+        { date: new Date('09/01/2012'), value:  -54.278},
+        { date: new Date('10/01/2012'), value:  -51.322},
+        { date: new Date('11/01/2012'), value:  -50.174},
+        { date: new Date('12/01/2012'), value:  -48.535},
+        { date: new Date('01/01/2013'), value:  -48.493},
+        { date: new Date('02/01/2013'), value:  -49.276},
+        { date: new Date('03/01/2013'), value:  -48.614},
+        { date: new Date('04/01/2013'), value:  -52.105},
+        { date: new Date('05/01/2013'), value:  -54.341},
+        { date: new Date('06/01/2013'), value:  -55.098},
+        { date: new Date('07/01/2013'), value:  -57.209},
+        { date: new Date('08/01/2013'), value:  -58.276},
+        { date: new Date('09/01/2013'), value:  -58.986},
+        { date: new Date('10/01/2013'), value:  -61.06},
+        { date: new Date('11/01/2013'), value:  -61.168},
+        { date: new Date('12/01/2013'), value:  -64.658},
+        { date: new Date('01/01/2014'), value:  -63.906},
+        { date: new Date('02/01/2014'), value:  -62.235},
+        { date: new Date('03/01/2014'), value:  -60.006},
+        { date: new Date('04/01/2014'), value:  -56.832},
+        { date: new Date('05/01/2014'), value:  -52.89},
+        { date: new Date('06/01/2014'), value:  -52.287},
+        { date: new Date('07/01/2014'), value:  -48.415}
     ]
 };
 
@@ -257,11 +290,13 @@ var units = {
     nullMultiple: ['quarterly', 'yearly'],
     nullStack: ['quarterly', 'yearly'],
     weekly: ['weekly', 'monthly', 'yearly'],
-    daily: ['daily', 'monthly', 'yearly']
+    daily: ['daily', 'monthly', 'yearly'],
+    allNegative: ['monthly', 'yearly']
 };
 var ySeriesData = {
     weekly: ['value'],
     daily: ['value'],
+    allNegative: ['value'],
     categories: ['value', 'value2'],
     categoriesStack: ['value', 'value2'],
     dateCategories: ['value', 'value2'],
@@ -315,7 +350,7 @@ module.exports = {
             'multiple', 'time', 'stack', 'stackMonthly', 'multipleWithNegatives', 'stackWithAllNegatives',
             'categories', 'categoriesStack', 'dateCategories', 'quarterCategories',
             'nullMultiple', 'nullValues', 'nullStack',
-            'weekly', 'daily'];
+            'weekly', 'daily', 'allNegative'];
         demos.forEach(function(timeFrame, i){
             var textContent = '';
             if (i===7){

--- a/src/scripts/util/data.model.js
+++ b/src/scripts/util/data.model.js
@@ -83,7 +83,7 @@ function sumStackedValues(model){
     return extents;
 }
 
-function dependentDomain(model){
+function dependentDomain(model, chartType){
     if(model.dependentDomain){ return model.dependentDomain; }
 
     var extents = (model.stack) ? sumStackedValues(model) : setExtents(model);
@@ -91,6 +91,12 @@ function dependentDomain(model){
     if(!model.falseOrigin && domain[0] > 0){
         domain[0] = 0;
     }
+
+    var isBarOrColumn = ['column', 'bar'].indexOf(chartType) >= 0;
+    if (isBarOrColumn && domain[1] < 0) {
+        domain[1] = 0;
+    }
+
     return domain;
 }
 
@@ -231,7 +237,7 @@ function Model(chartType, opts) {
 	m.data = verifyData(m);
     m.groupData = needsGrouping(m.units);
     m.independentDomain = independentDomain(m, chartType);
-	m.dependentDomain = dependentDomain(m);
+	m.dependentDomain = dependentDomain(m, chartType);
 	m.lineStrokeWidth = lineThickness(m.lineThickness);
 	m.key = setKey(m);
 

--- a/test/unit/util/data.model.spec.js
+++ b/test/unit/util/data.model.spec.js
@@ -218,4 +218,46 @@ describe('data model', function () {
         expect(model.lineStrokeWidth).toBe(10);
 
     });
+
+    it('sets the max value of the dependentDomain to zero when all values are neg on column and bar charts', function() {
+        var columnModel = new DataModel('column', {
+            height: 100,
+            width: 100,
+            key: true,
+            falseOrigin: false,
+            lineThickness: 10,
+            data: [
+                {quartersCol: new Date('2000-01-01T00:00:00.000Z'), qValue: -10.23, value2: -12},
+                {quartersCol: new Date('2001-01-01T00:00:00.000Z'), qValue: -29.23, value2: -29},
+                {quartersCol: new Date('2002-01-01T00:00:00.000Z'), qValue: -32.23, value2: -32},
+                {quartersCol: new Date('2003-01-01T00:00:00.000Z'), qValue: -39.23, value2: -37}
+            ],
+            units: ['quarterly','yearly'],
+            x: { series:{key:'quartersCol',label:'myValue'}},
+            y: { series: [{key:'qValue', label:'String Value'},
+                {key:'value2', label:'Another String Value'}]}
+        });
+        var barModel = new DataModel('bar', {
+            height: 100,
+            width: 100,
+            key: true,
+            falseOrigin: false,
+            lineThickness: 10,
+            data: [
+                {quartersCol: new Date('2000-01-01T00:00:00.000Z'), qValue: -10.23, value2: -12},
+                {quartersCol: new Date('2001-01-01T00:00:00.000Z'), qValue: -29.23, value2: -29},
+                {quartersCol: new Date('2002-01-01T00:00:00.000Z'), qValue: -32.23, value2: -32},
+                {quartersCol: new Date('2003-01-01T00:00:00.000Z'), qValue: -39.23, value2: -37}
+            ],
+            units: ['quarterly','yearly'],
+            x: { series:{key:'quartersCol',label:'myValue'}},
+            y: { series: [{key:'qValue', label:'String Value'},
+                {key:'value2', label:'Another String Value'}]}
+        });
+
+        expect(columnModel.dependentDomain[1]).toBe(0);
+        expect(barModel.dependentDomain[1]).toBe(0);
+
+    });
+
 });


### PR DESCRIPTION
Currently all-negative domains are not starting from zero. this fixes it:
![screen shot 2015-06-10 at 11 33 53](https://cloud.githubusercontent.com/assets/780409/8080861/f550bd76-0f67-11e5-9212-a9a34d15804f.png)


fixes https://github.com/Financial-Times/nightingale/issues/48